### PR TITLE
Fix duplicate process in periodic actor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+.DS_Store

--- a/src/shakespeare/actors/periodic.gleam
+++ b/src/shakespeare/actors/periodic.gleam
@@ -47,8 +47,6 @@ fn init(interval: Interval, do_work: Thunk) {
     process.new_selector()
     |> process.selecting(subject, identity)
 
-  process.send(subject, Run)
-
   enqueue_next_run(state)
   actor.Ready(state, selector)
 }

--- a/test/shakespeare/actors/periodic_test.gleam
+++ b/test/shakespeare/actors/periodic_test.gleam
@@ -6,16 +6,16 @@ import shakespeare/actors/periodic.{Ms}
 pub fn periodic_actor_test() {
   let assert Ok(counter) = key_value.start()
   key_value.set(counter, "count", 0)
-  key_value.set(counter, "count_min", 0)
+  key_value.set(counter, "count_loop", 0)
 
   let increment = fn() {
     let assert Ok(count) = key_value.get(counter, "count")
     key_value.set(counter, "count", count + 1)
   }
 
-  let increment_min = fn() {
-    let assert Ok(count) = key_value.get(counter, "count_min")
-    key_value.set(counter, "count_min", count + 1)
+  let increment_loop_count = fn() {
+    let assert Ok(count) = key_value.get(counter, "count_loop")
+    key_value.set(counter, "count_loop", count + 1)
   }
 
   periodic.start(do: increment, every: Ms(500))
@@ -24,14 +24,14 @@ pub fn periodic_actor_test() {
   loop_until(
     fn() {
       process.sleep(500)
-      increment_min()
+      increment_loop_count()
       key_value.get(counter, "count") == Ok(5)
     },
     start: 0,
     max: 15,
   )
 
-  key_value.get(counter, "count_min")
+  key_value.get(counter, "count_loop")
   |> should.equal(Ok(6))
 
   key_value.get(counter, "count")

--- a/test/shakespeare/actors/periodic_test.gleam
+++ b/test/shakespeare/actors/periodic_test.gleam
@@ -18,12 +18,12 @@ pub fn periodic_actor_test() {
     key_value.set(counter, "count_loop", count + 1)
   }
 
-  periodic.start(do: increment, every: Ms(500))
+  periodic.start(do: increment, every: Ms(10))
   |> should.be_ok
 
   loop_until(
     fn() {
-      process.sleep(500)
+      process.sleep(10)
       increment_loop_count()
       key_value.get(counter, "count") == Ok(5)
     },
@@ -32,7 +32,7 @@ pub fn periodic_actor_test() {
   )
 
   key_value.get(counter, "count_loop")
-  |> should.equal(Ok(6))
+  |> should.equal(Ok(5))
 
   key_value.get(counter, "count")
   |> should.equal(Ok(5))

--- a/test/shakespeare/actors/periodic_test.gleam
+++ b/test/shakespeare/actors/periodic_test.gleam
@@ -2,7 +2,6 @@ import gleam/erlang/process
 import gleeunit/should
 import shakespeare/actors/key_value
 import shakespeare/actors/periodic.{Ms}
-import gleam/result
 
 pub fn periodic_actor_test() {
   let assert Ok(counter) = key_value.start()
@@ -33,8 +32,7 @@ pub fn periodic_actor_test() {
   )
 
   key_value.get(counter, "count_min")
-  |> result.unwrap(100)
-  |> should.equal(6)
+  |> should.equal(Ok(6))
 
   key_value.get(counter, "count")
   |> should.equal(Ok(5))

--- a/test/shakespeare/actors/periodic_test.gleam
+++ b/test/shakespeare/actors/periodic_test.gleam
@@ -2,27 +2,39 @@ import gleam/erlang/process
 import gleeunit/should
 import shakespeare/actors/key_value
 import shakespeare/actors/periodic.{Ms}
+import gleam/result
 
 pub fn periodic_actor_test() {
   let assert Ok(counter) = key_value.start()
   key_value.set(counter, "count", 0)
+  key_value.set(counter, "count_min", 0)
 
   let increment = fn() {
     let assert Ok(count) = key_value.get(counter, "count")
     key_value.set(counter, "count", count + 1)
   }
 
-  periodic.start(do: increment, every: Ms(10))
+  let increment_min = fn() {
+    let assert Ok(count) = key_value.get(counter, "count_min")
+    key_value.set(counter, "count_min", count + 1)
+  }
+
+  periodic.start(do: increment, every: Ms(500))
   |> should.be_ok
 
   loop_until(
     fn() {
-      process.sleep(1)
+      process.sleep(500)
+      increment_min()
       key_value.get(counter, "count") == Ok(5)
     },
     start: 0,
     max: 15,
   )
+
+  key_value.get(counter, "count_min")
+  |> result.unwrap(100)
+  |> should.equal(6)
 
   key_value.get(counter, "count")
   |> should.equal(Ok(5))


### PR DESCRIPTION
Hi I was trying to use the periodic actor and I believe it was creating a duplicate process.

Issue:
**Duplicate process/function calls in the periodic actor**

Changes:
- Removed the `process.send(subject, Run)` line which I believe is unnecessary (correct me if I am wrong) and caused the duplicate process
- Updated periodic test to count the loops in order to check for correct period


Examples

Extra process:
<img width="1013" alt="Screenshot 2024-04-13 at 10 11 25 PM" src="https://github.com/maxdeviant/shakespeare/assets/24263908/9b7b2451-8c36-42e7-aa9b-fdf2a9b7f2e7">

With line removed:
<img width="1013" alt="Screenshot 2024-04-13 at 10 12 24 PM" src="https://github.com/maxdeviant/shakespeare/assets/24263908/39cd7a0e-7951-41bd-ab7c-f412b33fd6ed">
