### PR TITLE
Add `BroadcastActor`

### DIFF
--- a/src/shakespeare/actors/broadcast.gleam
+++ b/src/shakespeare/actors/broadcast.gleam
@@ -1,0 +1,70 @@
+//// An actor that broadcasts messages to multiple subjects.
+
+import gleam/erlang/process.{type Subject}
+import gleam/otp/actor
+import gleam/result
+import gleam/set.{type Set}
+
+/// An actor that broadcasts messages to multiple subjects.
+pub opaque type BroadcastActor(a) {
+  BroadcastActor(subject: Subject(Message(a)))
+}
+
+/// Starts a new `BroadcastActor`.
+pub fn start() -> Result(BroadcastActor(a), actor.StartError) {
+  actor.start(set.new(), handle_message)
+  |> result.map(BroadcastActor)
+}
+
+/// Adds a subject to list of subjects to broadcast to.
+///
+/// If this subject is already present, it will not be added again.
+pub fn register(actor: BroadcastActor(a), subject: Subject(a)) {
+  process.send(actor.subject, Register(subject))
+}
+
+/// Removes a subject from the list of subjects to broadcast to.
+///
+/// If this subject isn't present, nothing happens.
+pub fn unregister(actor: BroadcastActor(a), subject: Subject(a)) {
+  process.send(actor.subject, Unregister(subject))
+}
+
+/// Broadcasts a message to all registered subjects.
+///
+/// The order in which messages are delivered to
+/// each of the registered subjects is unspecified.
+pub fn send(actor: BroadcastActor(a), message: a) {
+  process.send(actor.subject, Send(message))
+}
+
+type Message(a) {
+  Register(subject: Subject(a))
+  Unregister(subject: Subject(a))
+  Send(msg: a)
+}
+
+fn handle_message(
+  message: Message(a),
+  state: Set(Subject(a)),
+) -> actor.Next(Message(a), Set(Subject(a))) {
+  case message {
+    Register(subject) ->
+      actor.continue(
+        state
+        |> set.insert(subject),
+      )
+
+    Unregister(subject) ->
+      actor.continue(
+        state
+        |> set.delete(subject),
+      )
+
+    Send(inner) -> {
+      state
+      |> set.fold(Nil, fn(_, dest) { process.send(dest, inner) })
+      actor.continue(state)
+    }
+  }
+}

--- a/test/shakespeare/actors/broadcast_test.gleam
+++ b/test/shakespeare/actors/broadcast_test.gleam
@@ -1,0 +1,54 @@
+import gleam/erlang/process
+import shakespeare/actors/broadcast
+import startest/expect
+
+type Foo {
+  Foo(seq: Int)
+}
+
+pub fn broadcast_actor_test() {
+  let subj1 = process.new_subject()
+  let subj2 = process.new_subject()
+
+  let assert Ok(broadcaster) = broadcast.start()
+
+  // Expect message to be received by single registered subject
+  broadcast.register(broadcaster, subj1)
+  broadcast.send(broadcaster, Foo(1))
+  process.receive(subj1, 100)
+  |> expect.to_equal(Ok(Foo(1)))
+
+  // Expect message to be received by both registered subjects
+  broadcast.register(broadcaster, subj2)
+  broadcast.send(broadcaster, Foo(2))
+  process.receive(subj1, 100)
+  |> expect.to_equal(Ok(Foo(2)))
+  process.receive(subj2, 100)
+  |> expect.to_equal(Ok(Foo(2)))
+
+  // Expect second add to be ignored
+  broadcast.register(broadcaster, subj1)
+  broadcast.send(broadcaster, Foo(3))
+  process.receive(subj1, 100)
+  |> expect.to_equal(Ok(Foo(3)))
+  process.receive(subj1, 100)
+  |> expect.to_equal(Error(Nil))
+  process.receive(subj2, 100)
+  |> expect.to_equal(Ok(Foo(3)))
+
+  // Expect unregister to work
+  broadcast.unregister(broadcaster, subj1)
+  broadcast.send(broadcaster, Foo(4))
+  process.receive(subj1, 100)
+  |> expect.to_equal(Error(Nil))
+  process.receive(subj2, 100)
+  |> expect.to_equal(Ok(Foo(4)))
+
+  // Expect unregister to work again, leaving no subjects
+  broadcast.unregister(broadcaster, subj2)
+  broadcast.send(broadcaster, Foo(5))
+  process.receive(subj1, 100)
+  |> expect.to_equal(Error(Nil))
+  process.receive(subj2, 100)
+  |> expect.to_equal(Error(Nil))
+}


### PR DESCRIPTION
As suggested by Hayleigh in https://discord.com/channels/768594524158427167/1240387487679906013 here's the PR for a simple actor to broadcast messages to any registered subjects.

Decided to use a Set instead of List in this more generic implementation, to ensure that the Register and Unregister calls are consistent (i.e. duplicates are ignored, instead of Register adding subjects multiple times, but Unregister removing all of them).

Hope you like it :)